### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,6 @@ You'll see an error:
 		    raise ValueError('The --custom_entrypoint flag must be set for '
 		ValueError: The --custom_entrypoint flag must be set for custom runtimes
 
-
-The Cloud SDK does not support anymore running custom runtimes when a Dockerfile is provided. You'll have to deploy the application to App Engine in the next section to see it running. 
-
 You can also specify a custom_entrypoint in your project pom.xml. This is an executable that the Cloud SDK will run to start your application locally. If you want to use the Cloud SDK bundled Jetty9 Web Server, you can define this entry point:
 
           <custom_entrypoint>java


### PR DESCRIPTION
Removed: "The Cloud SDK does not support anymore running custom runtimes when a Dockerfile is provided. You'll have to deploy the application to App Engine in the next section to see it running."

This isn't true, and custom runtimes can definitely be run in the dev environment, according to [the docs](https://cloud.google.com/appengine/docs/managed-vms/custom-runtimes). This README was [linked to](http://stackoverflow.com/questions/33764630/cannot-run-google-app-engine-custom-managed-vm-custom-entrypoint-must-be-set/33814096#33814096) by a user who took the removed statement as more authoritative than [the docs](https://cloud.google.com/appengine/docs/managed-vms/custom-runtimes).